### PR TITLE
Pass config options into resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "babel-plugin-module-alias": "^1.4.0",
     "json5": "^0.5.0",
+    "object-assign": "^4.0.1",
     "resolve": "^1.1.7"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ const resolverPlugin = require('../src/index');
 
 const opts = {
 };
+const extensionOpts = { extensions: ['.js', '.jsx'] };
 
 describe('eslint-import-resolver-module-alias', () => {
     it('should export the interfaceVersion', () => {
@@ -54,5 +55,31 @@ describe('eslint-import-resolver-module-alias', () => {
             .to.eql({ found: true, path: null });
         expect(resolverPlugin.resolve('path', path.resolve('./'), opts))
             .to.eql({ found: true, path: null });
+    });
+
+    it('should return `false` with a file with an unknown extension', () => {
+        expect(resolverPlugin.resolve('./c3', path.resolve('./test/examples/components/c1'), opts))
+            .to.eql({ found: false });
+    });
+
+    it('should return `true` with a file with an expected extension', () => {
+        expect(resolverPlugin.resolve('./c3', path.resolve('./test/examples/components/c1'), extensionOpts))
+            .to.eql({
+                found: true,
+                path: path.resolve(__dirname, './examples/components/c3.jsx')
+            });
+    });
+
+    it('should return `false` when mapped to a file with an unknown extension', () => {
+        expect(resolverPlugin.resolve('components/c3', path.resolve('./test/examples/components/subcomponent/sub/c2'), opts))
+            .to.eql({ found: false });
+    });
+
+    it('should return `true` when mapped to a file with an expected extension', () => {
+        expect(resolverPlugin.resolve('components/c3', path.resolve('./test/examples/components/subcomponent/sub/c2'), extensionOpts))
+            .to.eql({
+                found: true,
+                path: path.resolve(__dirname, './examples/components/c3.jsx')
+            });
     });
 });


### PR DESCRIPTION
I encountered false-positives with the `import/no-unresolved` rule because the files had `.jsx` extensions. I noticed that the default node resolver allowed custom extensions by [passing the config options into `resolve.sync`](https://github.com/benmosher/eslint-plugin-import/blob/master/resolvers/node/index.js#L10), so I made a similar change to this resolver's `resolve.sync`.